### PR TITLE
Slightly nicer config precedence. 

### DIFF
--- a/src/main/kotlin/krews/core/TaskRunContext.kt
+++ b/src/main/kotlin/krews/core/TaskRunContext.kt
@@ -1,5 +1,6 @@
 package krews.core
 
+import krews.config.TaskConfig
 import krews.config.convertConfigMap
 import krews.file.File
 import java.time.Duration
@@ -7,6 +8,7 @@ import java.time.Duration
 class TaskRunContextBuilder<I : Any, O : Any> internal constructor(
     val input: I,
     @PublishedApi internal val rawTaskParams: Map<String, Any>,
+    @PublishedApi internal val taskConfig: TaskConfig?,
     val outputClass: Class<O>
 ) {
     var dockerImage: String? = null
@@ -44,7 +46,8 @@ class TaskRunContextBuilder<I : Any, O : Any> internal constructor(
         diskSize = diskSize,
         time = time,
         taskParams = taskParams,
-        taskParamsClass = taskParamsClass
+        taskParamsClass = taskParamsClass,
+        taskConfig = taskConfig
     )
 }
 
@@ -61,5 +64,6 @@ data class TaskRunContext<I: Any, O: Any>(
     val diskSize: Capacity?,
     val time: Duration?,
     val taskParams: Any?,
-    val taskParamsClass: Class<*>?
+    val taskParamsClass: Class<*>?,
+    val taskConfig: TaskConfig?
 )

--- a/src/main/kotlin/krews/core/TaskRunner.kt
+++ b/src/main/kotlin/krews/core/TaskRunner.kt
@@ -130,7 +130,7 @@ class TaskRunner(private val workflowRun: WorkflowRun,
     private suspend fun <I : Any, O : Any> run(taskFuture: TaskRunFuture<I, O>) {
         val task = taskFuture.task
         val taskRunContext = taskFuture.taskRunContext
-        val taskConfig = workflowConfig.tasks[task.name]!!
+        val taskConfig = taskRunContext.taskConfig
 
         val inputJson = mapper
             .writerWithView(CacheView::class.java)

--- a/src/main/kotlin/krews/core/Workflow.kt
+++ b/src/main/kotlin/krews/core/Workflow.kt
@@ -5,11 +5,5 @@ import reactor.core.publisher.Flux
 
 class Workflow internal constructor(
     val name: String,
-    internal val tasks: Map<String, Task<*, *>>
-) {
-    @Suppress("UNCHECKED_CAST")
-    fun <I> taskInputPub(taskName: String) = tasks[taskName]!!.inputPub as Publisher<I>
-
-    @Suppress("UNCHECKED_CAST")
-    fun <O> taskOutputPub(taskName: String) = tasks[taskName]!!.outputPub as Flux<O>
-}
+    internal val tasks: Set<Task<*, *>>
+) {}

--- a/src/main/kotlin/krews/core/WorkflowBuilder.kt
+++ b/src/main/kotlin/krews/core/WorkflowBuilder.kt
@@ -4,14 +4,15 @@ import krews.config.convertConfigMap
 import org.reactivestreams.Publisher
 
 class WorkflowBuilder internal constructor(val name: String, private val init: WorkflowBuilder.() -> Unit) {
-    @PublishedApi internal val tasks: MutableMap<String, Task<*, *>> = mutableMapOf()
+    @PublishedApi internal val tasks: MutableSet<Task<*, *>> = mutableSetOf()
     @PublishedApi internal lateinit var rawParams: Map<String, Any>
     @PublishedApi internal var paramsOverride: Any? = null
+    @PublishedApi internal val taskNameSeen: MutableMap<String, Boolean> = mutableMapOf()
 
     fun importWorkflow(workflowBuilder: WorkflowBuilder, params: Any? = null): Workflow {
         workflowBuilder.paramsOverride = params
         val imported = workflowBuilder.build(mapOf())
-        this.tasks.putAll(imported.tasks)
+        this.tasks.addAll(imported.tasks)
         return imported
     }
 
@@ -30,8 +31,29 @@ class WorkflowBuilder internal constructor(val name: String, private val init: W
                                                        labels: List<String> = listOf(),
                                                        maintainOrder: Boolean = false,
                                                        noinline taskRunContextInit: TaskRunContextBuilder<I, O>.() -> Unit): Task<I, O> {
-        val task = Task(name, inputPub, labels, I::class.java, O::class.java, maintainOrder, taskRunContextInit)
-        this.tasks[task.name] = task
+        // The assumption here is that tasks with the same name, created in the same order are the same
+        // Technically, we can assign an id of whatever we want, it only has to be unique
+        // Only using the name may result in conflicts when the following occurs
+        // 1) The user creates two completely different tasks with the same name. This is usually unintended.
+        // 2) The user creates the same tasks multiple times (i.e. calls task(...) multiple times in a workflow).
+        //    This is may be intended when a single task needs to be done in different steps of the workflow.
+        // 3) The user creates the same task multiple times with a different closed environment.
+        //    This is almost almost always intended.
+        //
+        // For case 1, ideally we would error immediately, since logs could be confusing.
+        // For case 2, this should be fine. Having a different name for these may just introduce extra boilerplate.
+        // For case 3, it's unclear. Having different names makes having different configs straightforward, but may lead
+        // to extra boilerplate.
+        //
+        // The most correct ways to handle duplicate names is either to error immediately or fallback to a unique id
+        // Here, we error immediately and stop execution.
+        val seen = taskNameSeen.putIfAbsent(name, true)
+        if (seen == true) {
+            System.err.println("Task '$name' is duplicated. If you want to use it twice, call it with different names.")
+            System.exit(1)
+        }
+        val task = Task( name, inputPub, labels, I::class.java, O::class.java, maintainOrder, taskRunContextInit)
+        tasks.add(task)
         return task
     }
 

--- a/src/main/kotlin/krews/core/WorkflowRunner.kt
+++ b/src/main/kotlin/krews/core/WorkflowRunner.kt
@@ -128,12 +128,12 @@ class WorkflowRunner(
             taskRunner.startMonitorTasks()
 
             // Set execute function for each task.
-            for (task in workflow.tasks.values) {
+            for (task in workflow.tasks) {
                 task.connect(workflowConfig.tasks[task.name], taskRunner)
             }
 
             // Get "leafOutputs", meaning this workflow's task.output fluxes that don't have other task.outputs as parents
-            val allTaskOutputFluxes = workflow.tasks.values.map { it.outputPub }
+            val allTaskOutputFluxes = workflow.tasks.map { it.outputPub }
 
             // Trigger workflow by subscribing to leaf task outputs...
             val leavesFlux = Flux

--- a/src/main/kotlin/krews/executor/Executor.kt
+++ b/src/main/kotlin/krews/executor/Executor.kt
@@ -58,7 +58,7 @@ interface LocallyDirectedExecutor {
      */
     suspend fun executeTask(workflowRunDir: String,
                     taskRunId: Int,
-                    taskConfig: TaskConfig,
+                    taskConfig: TaskConfig?,
                     taskRunContext: TaskRunContext<*, *>,
                     outputFilesIn: Set<OutputFile>,
                     outputFilesOut: Set<OutputFile>,

--- a/src/main/kotlin/krews/executor/google/GoogleLocalExecutor.kt
+++ b/src/main/kotlin/krews/executor/google/GoogleLocalExecutor.kt
@@ -77,7 +77,7 @@ class GoogleLocalExecutor(private val workflowConfig: WorkflowConfig) : LocallyD
     override suspend fun executeTask(
         workflowRunDir: String,
         taskRunId: Int,
-        taskConfig: TaskConfig,
+        taskConfig: TaskConfig?,
         taskRunContext: TaskRunContext<*, *>,
         outputFilesIn: Set<OutputFile>,
         outputFilesOut: Set<OutputFile>,
@@ -92,8 +92,7 @@ class GoogleLocalExecutor(private val workflowConfig: WorkflowConfig) : LocallyD
 
         val virtualMachine = VirtualMachine()
         run.pipeline.resources.virtualMachine = virtualMachine
-        virtualMachine.machineType = googleMachineType(taskConfig.google, taskRunContext.cpus, taskRunContext.memory)
-
+        virtualMachine.machineType = googleMachineType(taskConfig?.google, taskRunContext.cpus, taskRunContext.memory)
         val serviceAccount = ServiceAccount()
         virtualMachine.serviceAccount = serviceAccount
         serviceAccount.scopes = listOf(STORAGE_READ_WRITE_SCOPE)
@@ -101,7 +100,7 @@ class GoogleLocalExecutor(private val workflowConfig: WorkflowConfig) : LocallyD
         val disk = Disk()
         virtualMachine.disks = listOf(disk)
         disk.name = DISK_NAME
-        if (taskConfig.google?.diskSize != null) {
+        if (taskConfig?.google?.diskSize != null) {
             disk.sizeGb = taskConfig.google.diskSize.toType(CapacityType.GB).toInt()
         }
 

--- a/src/main/kotlin/krews/executor/local/LocalExecutor.kt
+++ b/src/main/kotlin/krews/executor/local/LocalExecutor.kt
@@ -75,7 +75,7 @@ class LocalExecutor(workflowConfig: WorkflowConfig) : LocallyDirectedExecutor {
     override suspend fun executeTask(
         workflowRunDir: String,
         taskRunId: Int,
-        taskConfig: TaskConfig,
+        taskConfig: TaskConfig?,
         taskRunContext: TaskRunContext<*, *>,
         outputFilesIn: Set<OutputFile>,
         outputFilesOut: Set<OutputFile>,

--- a/src/main/kotlin/krews/executor/slurm/SlurmExecutor.kt
+++ b/src/main/kotlin/krews/executor/slurm/SlurmExecutor.kt
@@ -75,7 +75,7 @@ class SlurmExecutor(private val workflowConfig: WorkflowConfig) : LocallyDirecte
     override suspend fun executeTask(
         workflowRunDir: String,
         taskRunId: Int,
-        taskConfig: TaskConfig,
+        taskConfig: TaskConfig?,
         taskRunContext: TaskRunContext<*, *>,
         outputFilesIn: Set<OutputFile>,
         outputFilesOut: Set<OutputFile>,
@@ -104,11 +104,11 @@ class SlurmExecutor(private val workflowConfig: WorkflowConfig) : LocallyDirecte
         appendSbatchParam(sbatchScript, "job-name", slurmWorkflowJobName)
         appendSbatchParam(sbatchScript, "output", logsPath.resolve("out.txt"))
         appendSbatchParam(sbatchScript, "error", logsPath.resolve("err.txt"))
-        appendSbatchParam(sbatchScript, "mem", taskConfig.slurm?.mem ?: taskRunContext.memory)
-        appendSbatchParam(sbatchScript, "cpus-per-task", taskConfig.slurm?.cpus ?: taskRunContext.cpus)
-        appendSbatchParam(sbatchScript, "time", taskConfig.slurm?.time ?: taskRunContext.time)
-        appendSbatchParam(sbatchScript, "partition", taskConfig.slurm?.partition)
-        for ((argName, argVal) in taskConfig.slurm?.sbatchArgs ?: mapOf()) {
+        appendSbatchParam(sbatchScript, "mem", taskConfig?.slurm?.mem ?: taskRunContext.memory)
+        appendSbatchParam(sbatchScript, "cpus-per-task", taskConfig?.slurm?.cpus ?: taskRunContext.cpus)
+        appendSbatchParam(sbatchScript, "time", taskConfig?.slurm?.time ?: taskRunContext.time)
+        appendSbatchParam(sbatchScript, "partition", taskConfig?.slurm?.partition)
+        for ((argName, argVal) in taskConfig?.slurm?.sbatchArgs ?: mapOf()) {
             appendSbatchParam(sbatchScript, argName, argVal)
         }
 

--- a/src/test/kotlin/krews/ConfigTest.kt
+++ b/src/test/kotlin/krews/ConfigTest.kt
@@ -43,13 +43,13 @@ private fun configSampleWorkflow() = workflow("config-sample") {
         command = ""
     }
 
-    task<String, String>("sample2", "".toMono(), "small") {
+    task<String, String>("sample2", "".toMono(), "small2", "small") {
         dockerImage = "test"
         output = ""
         command = ""
     }
 
-    task<String, String>("sample3", "".toMono(), "large") {
+    task<String, String>("sample3", "".toMono(), "large", "small2") {
         dockerImage = "test"
         output = ""
         command = ""
@@ -132,8 +132,17 @@ private val completeTestConfig =
             }
         }
 
+        task.small2 {
+            params {
+                my-shared-thing = overridelabel
+            }
+        }
+
         # Overrides for gzip krews.core.task
         task.small {
+            params {
+                my-shared-thing = small
+            }
             google {
                 machine-type = n1-standard-1
                 disk-size = 5GB
@@ -150,6 +159,12 @@ private val completeTestConfig =
             }
             google {
                 disk-size = 30GB
+            }
+        }
+
+        task.sample3 {
+            params {
+                my-shared-thing = override
             }
         }
         """.trimIndent()
@@ -208,7 +223,7 @@ class ConfigTests : StringSpec({
 
         workflowConfig.tasks["sample2"] shouldBe TaskConfig(
             params = mapOf(
-                "my-shared-thing" to "someval"
+                "my-shared-thing" to "overridelabel"
             ),
             google = GoogleTaskConfig(
                 machineType = "n1-standard-1",
@@ -218,7 +233,7 @@ class ConfigTests : StringSpec({
 
         workflowConfig.tasks["sample3"] shouldBe TaskConfig(
             params = mapOf(
-                "my-shared-thing" to "someval"
+                "my-shared-thing" to "override"
             ),
             google = GoogleTaskConfig(
                 machineType = "n1-standard-2",


### PR DESCRIPTION
Log and stop execution immediately if any two tasks have the same name. Change some things so there's not as much reliance on task name, in case we want to allow duplicate names in the future too.